### PR TITLE
Simple case of NeoStick displaying ultrasonic value for percussion/me…

### DIFF
--- a/Software/PercussionStation/NeoPixel.cpp
+++ b/Software/PercussionStation/NeoPixel.cpp
@@ -22,5 +22,5 @@ static void applyFrame(WS2812Serial NeoStick, neoStickFrame_t frame)
 void updateNeoPixelStick(WS2812Serial NeoStick, uint8_t value)
 {
   value  = constrain(value, 0, 127);
-  applyFrame(NeoStick, countdownArray[value / 8]); 
+  applyFrame(NeoStick, countdownArray[(127 - value) / 8]); 
 }

--- a/Software/PercussionStation/PercussionStation.ino
+++ b/Software/PercussionStation/PercussionStation.ino
@@ -292,9 +292,8 @@ static void pingCheck(void)
   if(curr_bend_val != prev_bend_val && abs(curr_bend_val - prev_bend_val) < PREFS_P_BEND_ONEBYTE_MAX_DELTA)
   {
     usbMIDI.sendControlChange(in_config.pbend_cc, curr_bend_val, in_config.MIDI_Channel);
+    updateNeoPixelStick(NeoStick, curr_bend_val);
   }
-
-
 }
 
 
@@ -363,11 +362,15 @@ void printBanner(void)
  */
 static void myControlChange(byte channel, byte control, byte value)
 {
-  if ((channel != PREFS_MIDI_INPUT_CHANNEL) || (control != PREFS_MIDI_INPUT_CC))
-  {
-    return;
-  }
-  updateNeoPixelStick(NeoStick, value);
+
+  /**
+   * TODO FIXME currently unused
+   */
+  //  if ((channel != PREFS_MIDI_INPUT_CHANNEL) || (control != PREFS_MIDI_INPUT_CC))
+  //  {
+  //    return;
+  //  }
+  //  updateNeoPixelStick(NeoStick, value);
 }
 
 /**


### PR DESCRIPTION
…lodic stations

I'm going to make another separate Pull Request for a more complex version, one that will use the StationType in EEPROM to set the strip colors to match the station arcade button colors. But for now this will work in a pinch and is so simple I have high expectations that it will work off the bat.

NOTE: For NeoPixel.cpp, I have to flip the value to make sense now for ultrasonic range as opposed to countdown time. Could re-write the function but this is fine enough.. Maybe the complex case will redo the array order, since it already has to redo the array contents