### PR TITLE
Submit changes for Button Brightness and Ultrasonic Springback Constant

### DIFF
--- a/Software/PercussionStation/PercussionStation.ino
+++ b/Software/PercussionStation/PercussionStation.ino
@@ -275,7 +275,7 @@ static void pingCheck(void)
 
   if (range_in_us == 0)
   {
-    curr_bend_val = (curr_bend_val >= 2) ? curr_bend_val-2 : 0;
+    curr_bend_val = (curr_bend_val >= PREFS_ULTRA_SPRINGBACK_VAL) ? curr_bend_val - PREFS_ULTRA_SPRINGBACK_VAL : 0;
   }
   else
   {
@@ -285,11 +285,11 @@ static void pingCheck(void)
     }
     
     /* convert ultrasonic range to value for MIDI CC and send it */
-    curr_bend_val = P_BEND_ONEBYTE_VALUE(range_in_cm);
+    curr_bend_val = ULTRA_ONEBYTE_VALUE(range_in_cm);
     curr_bend_val = constrain(curr_bend_val, 0, 127);
   }
 
-  if(curr_bend_val != prev_bend_val && abs(curr_bend_val - prev_bend_val) < PREFS_P_BEND_ONEBYTE_MAX_DELTA)
+  if(curr_bend_val != prev_bend_val && abs(curr_bend_val - prev_bend_val) < PREFS_ULTRA_ONEBYTE_MAX_DELTA)
   {
     usbMIDI.sendControlChange(in_config.pbend_cc, curr_bend_val, in_config.MIDI_Channel);
   }

--- a/Software/PercussionStation/Preferences.h
+++ b/Software/PercussionStation/Preferences.h
@@ -38,18 +38,19 @@
 
 
 /* Ultrasonic / pitch bend preferences */
-#define PREFS_ULTRA_MAX_CM 30
+#define PREFS_ULTRA_MAX_CM 30 // change this to change the far range of what the ultrasonic can "see" - in centimeters
 #define PREFS_ULTRA_PING_PERIOD (unsigned long) (33)
-#define PREFS_P_BEND_MAX_DELTA 1700
-#define PREFS_P_BEND_ONEBYTE_MAX_DELTA 8
+#define PREFS_ULTRA_MAX_DELTA 1700
+#define PREFS_ULTRA_ONEBYTE_MAX_DELTA 8
+#define PREFS_ULTRA_SPRINGBACK_VAL 5 // amount of "spring constant" for when ultrasonic is not being controlled by a user. Units are 0-127 CC value
 
 /* Button preferences */
 #define PREFS_BUTTON_DEBOUNCE_MSEC 10
 #define PREFS_BUTTON_CC_LOW_VAL 0 // what CC corresponds to button OFF
 #define PREFS_BUTTON_CC_HIGH_VAL 127 // what CC val corresponds to button ON
-#define PREFS_ARCADE_BUTTON_PWM_HIGH 200
-#define PREFS_ARCADE_BUTTON_PWM_LOW_ABSENCE 0
-#define PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE 30
+#define PREFS_ARCADE_BUTTON_PWM_HIGH 255 // Button brightness from 0-255 that determines how lit up the arcade buttons are when pressed
+#define PREFS_ARCADE_BUTTON_PWM_LOW_ABSENCE 0 // Button brightness when completely off/ presence is not detected
+#define PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE 30 // Button brightnes when presence is detected but the button is not currently being pressed Top of ramp value
 
 /* Joystick preferences */
 #define PREFS_JOYSTICK_DEBOUNCE_MSEC 300
@@ -60,8 +61,8 @@
 #define PREFS_LIN_POT_MIN_READING 10
 
 /* MIDI preferences */
-#define PREFS_MIDI_INPUT_CHANNEL   MIDI_CHANNEL_15
-#define PREFS_MIDI_INPUT_CC        MIDI_GEN_PURPOSE_8   
+#define PREFS_MIDI_INPUT_CHANNEL   MIDI_CHANNEL_15    // currently unused
+#define PREFS_MIDI_INPUT_CC        MIDI_GEN_PURPOSE_8 // currently unused  
 
 #define PREFS_RAMP_PERIOD 500
 #define PREFS_RAMP_INCREMENTS 10

--- a/Software/PercussionStation/Ultrasonic.h
+++ b/Software/PercussionStation/Ultrasonic.h
@@ -10,10 +10,8 @@
 #ifndef __ULTRASONIC_H__
 #define __ULTRASONIC_H__
 
-/**
- * This file is now very barebones because the NewPing library is doing the heavy-lifting for the Ultrasonic firmware 
- */
-#define P_BEND_MAX_CM 30 // adjust this for sensitivity range of pitch bend
+#include "Preferences.h" // for PREFS_ULTRA_MAX_CM
+
 
 /**
  * MIDI Pitch bend message accepts a 14-bit twos compliment value, 
@@ -22,12 +20,12 @@
  * 
  * NOTE: use pow(2,13) instead for full range!
  */
-#define P_BEND_SCALED_VALUE(x) (int) (pow(2,12) * x  / P_BEND_MAX_CM) - pow(2,12)  // Do not adjust!
+#define ULTRA_SCALED_VALUE(x) (int) (pow(2,12) * x  / PREFS_ULTRA_MAX_CM) - pow(2,12)  // Do not adjust!
 
 /**
  * If using pitch bend for another MIDI control code, the range is only 0-127
  */
-#define P_BEND_ONEBYTE_VALUE(x) (int) (pow(2,7) * (P_BEND_MAX_CM - x)  / P_BEND_MAX_CM)  // Do not adjust!
+#define ULTRA_ONEBYTE_VALUE(x) (int) (pow(2,7) * (PREFS_ULTRA_MAX_CM - x)  / PREFS_ULTRA_MAX_CM)  // Do not adjust!
 
 
 #endif // __ULTRASONIC_H__

--- a/Software/SweepStation/Preferences.h
+++ b/Software/SweepStation/Preferences.h
@@ -37,22 +37,23 @@
 #endif /* DEBUG */
 
 /* Ultrasonic / pitch bend preferences */
-#define PREFS_ULTRA_MAX_CM 30
+#define PREFS_ULTRA_MAX_CM 30 // change this to change the far range of what the ultrasonic can "see" - in centimeters
 #define PREFS_ULTRA_PING_PERIOD (unsigned long) (30)
-#define PREFS_P_BEND_MAX_DELTA 1700
-#define PREFS_P_BEND_ONEBYTE_MAX_DELTA 10
+#define PREFS_ULTRA_MAX_DELTA 1700
+#define PREFS_ULTRA_ONEBYTE_MAX_DELTA 10
+#define PREFS_ULTRA_SPRINGBACK_VAL 5 // amount of "spring constant" for when ultrasonic is not being controlled by a user. Units are 0-127 CC value
 
 /* Button preferences */
 #define PREFS_BUTTON_DEBOUNCE_MSEC 10
 #define PREFS_BUTTON_CC_LOW_VAL 0 // what CC corresponds to button OFF
 #define PREFS_BUTTON_CC_HIGH_VAL 127 // what CC val corresponds to button ON
-#define PREFS_ARCADE_BUTTON_PWM_HIGH 200
-#define PREFS_ARCADE_BUTTON_PWM_LOW_ABSENCE 0
-#define PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE 30
+#define PREFS_ARCADE_BUTTON_PWM_HIGH 255 // Button brightness from 0-255 that determines how lit up the arcade buttons are when pressed
+#define PREFS_ARCADE_BUTTON_PWM_LOW_ABSENCE 0 // Button brightness when completely off/ presence is not detected
+#define PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE 30 // Button brightnes when presence is detected but the button is not currently being pressed Top of ramp value
 
 /* MIDI preferences */
-#define PREFS_MIDI_INPUT_CHANNEL   MIDI_CHANNEL_15
-#define PREFS_MIDI_INPUT_CC        MIDI_GEN_PURPOSE_8   
+#define PREFS_MIDI_INPUT_CHANNEL   MIDI_CHANNEL_15    // currently unused
+#define PREFS_MIDI_INPUT_CC        MIDI_GEN_PURPOSE_8 // currently unused    
 
 #define PREFS_RAMP_PERIOD 500
 #define PREFS_RAMP_INCREMENTS 10

--- a/Software/SweepStation/SweepStation.ino
+++ b/Software/SweepStation/SweepStation.ino
@@ -73,11 +73,11 @@ ArcadeButton ArcadeButton1(SWEEP_STATION_BUTTON_1, SWEEP_STATION_LED_1, BUTTON_1
 
 NewPing ultrasonicLeft( SWEEP_STATION_LEFT_ULTRA_TRIG, // Trigger pin
                    SWEEP_STATION_LEFT_ULTRA_SENS, // Sense pin
-                   P_BEND_MAX_CM + 1); // Max distance limit
+                   PREFS_ULTRA_MAX_CM + 1); // Max distance limit
 
 NewPing ultrasonicRight(SWEEP_STATION_RIGHT_ULTRA_TRIG, // Trigger pin
                    SWEEP_STATION_RIGHT_ULTRA_SENS, // Sense pin
-                   P_BEND_MAX_CM + 1); // Max distance limit
+                   PREFS_ULTRA_MAX_CM + 1); // Max distance limit
 
 WS2812Serial NeoStickLeft(NeoStick_count, 
                       NeoStickLeft_displayMemory, 
@@ -255,7 +255,7 @@ static void pingCheck(bool nextPingIsLeft)
     
     if (left_range_in_us == 0)
     {
-      left_curr_bend_val = (left_curr_bend_val >= 5) ? left_curr_bend_val-5 : 0;
+      left_curr_bend_val = (left_curr_bend_val >= PREFS_ULTRA_SPRINGBACK_VAL) ? left_curr_bend_val - PREFS_ULTRA_SPRINGBACK_VAL : 0;
     }
     else
     {
@@ -265,11 +265,11 @@ static void pingCheck(bool nextPingIsLeft)
       }
       
       /* convert ultrasonic range to value for MIDI CC and send it */
-      left_curr_bend_val = P_BEND_ONEBYTE_VALUE(left_range_in_cm);
+      left_curr_bend_val = ULTRA_ONEBYTE_VALUE(left_range_in_cm);
       left_curr_bend_val = constrain(left_curr_bend_val, 0, 127);
     }
   
-    if(left_curr_bend_val != left_prev_bend_val && abs(left_curr_bend_val - left_prev_bend_val) < PREFS_P_BEND_ONEBYTE_MAX_DELTA)
+    if(left_curr_bend_val != left_prev_bend_val && abs(left_curr_bend_val - left_prev_bend_val) < PREFS_ULTRA_ONEBYTE_MAX_DELTA)
     {
       usbMIDI.sendControlChange(in_config.pbend_left_cc, left_curr_bend_val, in_config.MIDI_Channel);
       updateNeoPixelStick(NeoStickLeft, left_curr_bend_val);
@@ -282,7 +282,7 @@ static void pingCheck(bool nextPingIsLeft)
     
     if (right_range_in_us == 0)
     {
-      right_curr_bend_val = (right_curr_bend_val >= 5) ? right_curr_bend_val-5 : 0;
+      right_curr_bend_val = (right_curr_bend_val >= PREFS_ULTRA_SPRINGBACK_VAL) ? right_curr_bend_val - PREFS_ULTRA_SPRINGBACK_VAL : 0;
     }
     else
     {
@@ -292,11 +292,11 @@ static void pingCheck(bool nextPingIsLeft)
       }
       
       /* convert ultrasonic range to value for MIDI CC and send it */
-      right_curr_bend_val = P_BEND_ONEBYTE_VALUE(right_range_in_cm);
+      right_curr_bend_val = ULTRA_ONEBYTE_VALUE(right_range_in_cm);
       right_curr_bend_val = constrain(right_curr_bend_val, 0, 127);
     }
   
-    if(right_curr_bend_val != right_prev_bend_val && abs(right_curr_bend_val - right_prev_bend_val) < PREFS_P_BEND_ONEBYTE_MAX_DELTA)
+    if(right_curr_bend_val != right_prev_bend_val && abs(right_curr_bend_val - right_prev_bend_val) < PREFS_ULTRA_ONEBYTE_MAX_DELTA)
     {
       usbMIDI.sendControlChange(in_config.pbend_right_cc, right_curr_bend_val, in_config.MIDI_Channel);
       updateNeoPixelStick(NeoStickRight, right_curr_bend_val);

--- a/Software/SweepStation/Ultrasonic.h
+++ b/Software/SweepStation/Ultrasonic.h
@@ -10,10 +10,8 @@
 #ifndef __ULTRASONIC_H__
 #define __ULTRASONIC_H__
 
-/**
- * This file is now very barebones because the NewPing library is doing the heavy-lifting for the Ultrasonic firmware 
- */
-#define P_BEND_MAX_CM 30 // adjust this for sensitivity range of pitch bend
+#include "Preferences.h" // for PREFS_ULTRA_MAX_CM
+
 
 /**
  * MIDI Pitch bend message accepts a 14-bit twos compliment value, 
@@ -22,12 +20,12 @@
  * 
  * NOTE: use pow(2,13) instead for full range!
  */
-#define P_BEND_SCALED_VALUE(x) (int) (pow(2,12) * x  / P_BEND_MAX_CM) - pow(2,12)  // Do not adjust!
+#define ULTRA_SCALED_VALUE(x) (int) (pow(2,12) * x  / PREFS_ULTRA_MAX_CM) - pow(2,12)  // Do not adjust!
 
 /**
  * If using pitch bend for another MIDI control code, the range is only 0-127
  */
-#define P_BEND_ONEBYTE_VALUE(x) (int) (pow(2,7) * (P_BEND_MAX_CM - x)  / P_BEND_MAX_CM)  // Do not adjust!
+#define ULTRA_ONEBYTE_VALUE(x) (int) (pow(2,7) * (PREFS_ULTRA_MAX_CM - x)  / PREFS_ULTRA_MAX_CM)  // Do not adjust!
 
 
 #endif // __ULTRASONIC_H__


### PR DESCRIPTION
Move PREFS_ULTRA_MAX_CM to one variable, make the arcade buttons brighter when pushed, make the ultrasonic "springback" (CC to zero after one lets off the ultrasonic sensor).

Also remove all references to P(itch)_BEND for the ultrasonic sensor, as it does not really do that for this project.