### PR TITLE
Submit EEPROM code to allow for flipping individual ultrasonic sensors

### DIFF
--- a/Software/PercussionStation/NeoPixel.cpp
+++ b/Software/PercussionStation/NeoPixel.cpp
@@ -10,32 +10,34 @@
 #include "NeoPixel.h"
 #include "Nonvolatile.h"
 
-static void applyFrame(WS2812Serial NeoStick, neoStickFrame_t frame)
+static void applyFrame(WS2812Serial NeoStick, neoStickFrame_t frame, bool invert)
 {
   for (int i = 0; i < NeoStick_count; i++)
   {
-    NeoStick.setPixel(i, frame.pixelArray[i].green, frame.pixelArray[i].red, frame.pixelArray[i].blue);
+    /* Flip the NeoStick lights if EEPROM dictates that we should (this is based on physical install) */
+    int pixelIdx = (invert) ? (NeoStick_count - i) : i;    
+    NeoStick.setPixel(i, frame.pixelArray[pixelIdx].green, frame.pixelArray[pixelIdx].red, frame.pixelArray[pixelIdx].blue);
   }
   NeoStick.show();
 }
 
 
-void updateNeoPixelStick(WS2812Serial NeoStick, uint8_t value, stationType_t hwType)
+void updateNeoPixelStick(WS2812Serial NeoStick, uint8_t value, stationType_t hwType, neoStripInvertState_t invert)
 {
   value  = constrain(value, 0, 127);
   switch(hwType)
   {
     case STATION_TYPE_PERCUSSION:
       // NeoStick.setPixel has a prototype like setPixel(uint16_t index, uint8_t red, uint8_t green, uint8_t blue)
-      applyFrame(NeoStick, blueArray[value / 8]); 
+      applyFrame(NeoStick, blueArray[value / 8], (invert == NEOSTRIP_INVERT_YES)); 
       break;
       
     case STATION_TYPE_MELODIC:
-      applyFrame(NeoStick, yellowArray[value / 8]); 
+      applyFrame(NeoStick, yellowArray[value / 8], (invert == NEOSTRIP_INVERT_YES)); 
       break;
       
     case   STATION_TYPE_SWEEP:
-      applyFrame(NeoStick, whiteArray[value / 8]); 
+      applyFrame(NeoStick, whiteArray[value / 8], (invert == NEOSTRIP_INVERT_YES)); 
       break;
 
     default :

--- a/Software/PercussionStation/NeoPixel.h
+++ b/Software/PercussionStation/NeoPixel.h
@@ -86,7 +86,7 @@ const neoStickFrame_t whiteArray[16] = {
   {{{100,100,100},{100,100,100},{100,100,100},{100,100,100},{100,100,100},{100,100,100},{100,100,100},{100,100,100}}}
   };
 
-void updateNeoPixelStick(WS2812Serial NeoStick, uint8_t value, stationType_t hwType); // Update LED values based on remaining time 
+void updateNeoPixelStick(WS2812Serial NeoStick, uint8_t value, stationType_t hwType, neoStripInvertState_t invert); // Update LED values based on remaining time 
 
 
 #endif // __NEOPIXEL_H__

--- a/Software/PercussionStation/Nonvolatile.cpp
+++ b/Software/PercussionStation/Nonvolatile.cpp
@@ -35,6 +35,7 @@ void printNonvolConfig(void)
   Serial.printf("  Device ID: %02d\r\n", EEPROM.read(EEPROM_ADDR_STATION_ID));
   Serial.printf("  Station Type: %s\r\n", StationTypeToStr((stationType_t) EEPROM.read(EEPROM_ADDR_STATION_TYPE)));
   Serial.printf("  MIDI Channel: 0x%02x\r\n", EEPROM.read(EEPROM_ADDR_MIDI_CHANNEL));
+  Serial.printf("  Invert NeoStick: %s\r\n", (NEOSTRIP_INVERT_YES == EEPROM.read(EEPROM_ADDR_INVERT_NEOSTRIP_1)) ? "True" : "False");
   DEBUG_PRINTLN("*** DONE ***");
   DEBUG_PRINTLN();
 }

--- a/Software/PercussionStation/Nonvolatile.h
+++ b/Software/PercussionStation/Nonvolatile.h
@@ -19,13 +19,25 @@ enum stationType_t
 };
 
 /**
+ * Interpret whether to invert the NeoStrip by using value or (127 - value) in the xStation functions that set the neostrip index 
+ */
+enum neoStripInvertState_t
+{
+  NEOSTRIP_INVERT_YES     = 0x00,
+  NEOSTRIP_INVERT_NO      = 0x01,
+  NEOSTRIP_INVERT_DEFAULT = 0xFF  // NOTE that unset EEPROM regions empirically default to 0xFF on Teensy, this will be logically equivalent to a NEOSTRIP_INVERT_NO
+};
+
+/**
  * EEPROM layout
  */
-#define EEPROM_ADDR_MIN 0x00
-#define EEPROM_ADDR_STATION_ID   0x10
-#define EEPROM_ADDR_STATION_TYPE 0x11
-#define EEPROM_ADDR_MIDI_CHANNEL 0x12
-#define EEPROM_ADDR_MAX 0x7F // this is the limit for the TEENSY_LC
+#define EEPROM_ADDR_MIN               0x00
+#define EEPROM_ADDR_STATION_ID        0x10
+#define EEPROM_ADDR_STATION_TYPE      0x11
+#define EEPROM_ADDR_MIDI_CHANNEL      0x12
+#define EEPROM_ADDR_INVERT_NEOSTRIP_1 0x13
+#define EEPROM_ADDR_INVERT_NEOSTRIP_2 0x14
+#define EEPROM_ADDR_MAX               0x7F // this is the limit for the TEENSY_LC
 
 void printNonvolConfig(void);
 

--- a/Software/PercussionStation/PercussionStation.ino
+++ b/Software/PercussionStation/PercussionStation.ino
@@ -132,7 +132,8 @@ void setup()
   in_config.thumb_cc     = MIDI_UNDEFINED_2;
   in_config.presence_cc  = MIDI_UNDEFINED_3;
   in_config.MIDI_Channel = EEPROM.read(EEPROM_ADDR_MIDI_CHANNEL);
-  in_config.HW_Type = (stationType_t) EEPROM.read(EEPROM_ADDR_STATION_TYPE);
+  in_config.HW_Type      = (stationType_t) EEPROM.read(EEPROM_ADDR_STATION_TYPE);
+  in_config.invert       = (neoStripInvertState_t) EEPROM.read(EEPROM_ADDR_INVERT_NEOSTRIP_1);
 
   ArcadeButton0.SetMIDIParams(in_config.MIDI_Channel, in_config.button0_cc);
   ArcadeButton1.SetMIDIParams(in_config.MIDI_Channel, in_config.button1_cc);
@@ -318,7 +319,7 @@ static void pingCheck(void)
   if(curr_bend_val != prev_bend_val && abs(curr_bend_val - prev_bend_val) < PREFS_ULTRA_ONEBYTE_MAX_DELTA)
   {
     usbMIDI.sendControlChange(in_config.pbend_cc, curr_bend_val, in_config.MIDI_Channel);
-    updateNeoPixelStick(NeoStick, curr_bend_val, in_config.HW_Type);
+    updateNeoPixelStick(NeoStick, curr_bend_val, in_config.HW_Type, in_config.invert);
   }
 }
 

--- a/Software/PercussionStation/Preferences.h
+++ b/Software/PercussionStation/Preferences.h
@@ -100,6 +100,7 @@ typedef struct
   uint8_t presence_cc;
   uint8_t MIDI_Channel;
   stationType_t HW_Type;
+  neoStripInvertState_t invert;
 } config_t;
 
 #endif //__PREFERENCES_H__

--- a/Software/ProvisionEEPROM/ConfigEEPROM.h
+++ b/Software/ProvisionEEPROM/ConfigEEPROM.h
@@ -19,13 +19,25 @@ enum stationType_t
 };
 
 /**
+ * Interpret whether to invert the neostrip by using value or (127 - value) in the xStation functions that set the neostrip index 
+ */
+enum neoStripInvertState_t
+{
+  NEOSTRIP_INVERT_YES     = 0x00,
+  NEOSTRIP_INVERT_NO      = 0x01,
+  NEOSTRIP_INVERT_DEFAULT = 0xFF  // NOTE that unset EEPROM regions empirically default to 0xFF on Teensy, this will be logically equivalent to a NEOSTRIP_INVERT_NO
+};
+
+/**
  * EEPROM layout
  */
-#define EEPROM_ADDR_MIN 0x00
-#define EEPROM_ADDR_STATION_ID   0x10
-#define EEPROM_ADDR_STATION_TYPE 0x11
-#define EEPROM_ADDR_MIDI_CHANNEL 0x12
-#define EEPROM_ADDR_MAX 0x7F // this is the limit for the TEENSY_LC
+#define EEPROM_ADDR_MIN               0x00
+#define EEPROM_ADDR_STATION_ID        0x10
+#define EEPROM_ADDR_STATION_TYPE      0x11
+#define EEPROM_ADDR_MIDI_CHANNEL      0x12
+#define EEPROM_ADDR_INVERT_NEOSTRIP_1 0x13
+#define EEPROM_ADDR_INVERT_NEOSTRIP_2 0x14
+#define EEPROM_ADDR_MAX               0x7F // this is the limit for the TEENSY_LC
 
 
 #endif // __CONFIG_EEPROM_H__

--- a/Software/ProvisionEEPROM/ProvisionEEPROM.ino
+++ b/Software/ProvisionEEPROM/ProvisionEEPROM.ino
@@ -9,7 +9,7 @@
  *  Tested with Teensy 4.1
  *******************************************************/
 #include <EEPROM.h>
-
+#include "Arduino.h"
 #include "ConfigEEPROM.h"
 
 #define DEBUG_PRINTLN(x)  Serial.println(x)
@@ -21,11 +21,18 @@
 #define TEENSY_LED_PIN 13
 
 /**
+ * Tell this program what to do- if set to true, we will write the values below, else we will just read them
+ */
+const bool rewrite_the_EEPROM = false;
+
+/**
  * START EEPROM preferences to be written
  */
 const uint8_t THIS_STATION_ID = 0x6;
 const uint8_t THIS_MIDI_CHANNEL = 0x6;
 const stationType_t THIS_STATION_TYPE = STATION_TYPE_SWEEP;
+const neoStripInvertState_t INVERT_STATION_1 = NEOSTRIP_INVERT_NO;
+const neoStripInvertState_t INVERT_STATION_2 = NEOSTRIP_INVERT_NO;
 /**
  * END EEPROM preferences to be written
  */
@@ -45,7 +52,7 @@ static void printBanner(void); // Print a serial welcome banner
 /**
  * Add additional EEPROM config values here
  */
-static void updateEEPROM(uint8_t stationID, uint8_t midiChannel);
+static void updateEEPROM(uint8_t stationID, uint8_t midiChannel, stationType_t stationType, neoStripInvertState_t invert1, neoStripInvertState_t invert2);
 
 /**
  * print out all the values from the EEPROM
@@ -62,8 +69,15 @@ void setup()
   while(!Serial);
   
   printBanner();
-  DEBUG_PRINTLN("* Updating EEPROM *");
-  updateEEPROM(THIS_STATION_ID, THIS_MIDI_CHANNEL, THIS_STATION_TYPE );
+  if (rewrite_the_EEPROM)
+  {
+    DEBUG_PRINTLN("* Updating EEPROM *");
+    updateEEPROM(THIS_STATION_ID, THIS_MIDI_CHANNEL, THIS_STATION_TYPE, INVERT_STATION_1, INVERT_STATION_2 );
+  }
+  else
+  {
+    DEBUG_PRINTLN("* Variable \"rewrite_the_EEPROM\" not set, only printing EEPROM values *");
+  }
   DEBUG_PRINTLN();
   DEBUG_PRINTLN("* Printing EEPROM *");
   printEEPROM();
@@ -80,11 +94,13 @@ void loop()
 /**
  * Check and set
  */
-static void updateEEPROM(uint8_t stationID, uint8_t midiChannel, stationType_t stationType)
+static void updateEEPROM(uint8_t stationID, uint8_t midiChannel, stationType_t stationType, neoStripInvertState_t invert1, neoStripInvertState_t invert2)
 {
   EEPROMCheckAndSet(EEPROM_ADDR_STATION_ID, stationID);
   EEPROMCheckAndSet(EEPROM_ADDR_MIDI_CHANNEL, midiChannel);  
   EEPROMCheckAndSet(EEPROM_ADDR_STATION_TYPE, (uint8_t) stationType);  
+  EEPROMCheckAndSet(EEPROM_ADDR_INVERT_NEOSTRIP_1, (uint8_t) invert1);  
+  EEPROMCheckAndSet(EEPROM_ADDR_INVERT_NEOSTRIP_2, (uint8_t) invert2);  
 }
 
 static void printEEPROM(void)

--- a/Software/SweepStation/NeoPixel.cpp
+++ b/Software/SweepStation/NeoPixel.cpp
@@ -10,32 +10,34 @@
 #include "NeoPixel.h"
 #include "Nonvolatile.h" // for stationType_t
 
-static void applyFrame(WS2812Serial NeoStick, neoStickFrame_t frame)
+static void applyFrame(WS2812Serial NeoStick, neoStickFrame_t frame, bool invert)
 {
   for (int i = 0; i < NeoStick_count; i++)
   {
-    NeoStick.setPixel(i, frame.pixelArray[i].green, frame.pixelArray[i].red, frame.pixelArray[i].blue);
+    /* Flip the NeoStick lights if EEPROM dictates that we should (this is based on physical install) */
+    int pixelIdx = (invert) ? (NeoStick_count - i) : i;
+    NeoStick.setPixel(i, frame.pixelArray[pixelIdx].green, frame.pixelArray[pixelIdx].red, frame.pixelArray[pixelIdx].blue);
   }
   NeoStick.show();
 }
 
 
-void updateNeoPixelStick(WS2812Serial NeoStick, uint8_t value, stationType_t hwType)
+void updateNeoPixelStick(WS2812Serial NeoStick, uint8_t value, stationType_t hwType, neoStripInvertState_t invert)
 {
   value  = constrain(value, 0, 127);
   switch(hwType)
   {
     case STATION_TYPE_PERCUSSION:
       // NeoStick.setPixel has a prototype like setPixel(uint16_t index, uint8_t red, uint8_t green, uint8_t blue)
-      applyFrame(NeoStick, blueArray[value / 8]); 
+      applyFrame(NeoStick, blueArray[value / 8], (invert == NEOSTRIP_INVERT_YES)); 
       break;
       
     case STATION_TYPE_MELODIC:
-      applyFrame(NeoStick, yellowArray[value / 8]); 
+      applyFrame(NeoStick, yellowArray[value / 8], (invert == NEOSTRIP_INVERT_YES)); 
       break;
       
     case   STATION_TYPE_SWEEP:
-      applyFrame(NeoStick, whiteArray[value / 8]); 
+      applyFrame(NeoStick, whiteArray[value / 8], (invert == NEOSTRIP_INVERT_YES)); 
       break;
 
     default :

--- a/Software/SweepStation/NeoPixel.h
+++ b/Software/SweepStation/NeoPixel.h
@@ -86,6 +86,6 @@ const neoStickFrame_t whiteArray[16] = {
   {{{100,100,100},{100,100,100},{100,100,100},{100,100,100},{100,100,100},{100,100,100},{100,100,100},{100,100,100}}}
   };
 
-void updateNeoPixelStick(WS2812Serial NeoStick, uint8_t value, stationType_t hwType); // Update LED values based on remaining time 
+void updateNeoPixelStick(WS2812Serial NeoStick, uint8_t value, stationType_t hwType, neoStripInvertState_t invert); // Update LED values based on remaining time 
 
 #endif // __NEOPIXEL_H__

--- a/Software/SweepStation/Nonvolatile.cpp
+++ b/Software/SweepStation/Nonvolatile.cpp
@@ -41,6 +41,8 @@ void printNonvolConfig(void)
   Serial.printf("  Device ID: %02d\r\n", EEPROM.read(EEPROM_ADDR_STATION_ID));
   Serial.printf("  Station Type: %s\r\n", StationTypeToStr((stationType_t) EEPROM.read(EEPROM_ADDR_STATION_TYPE)));
   Serial.printf("  MIDI Channel: 0x%02x\r\n", EEPROM.read(EEPROM_ADDR_MIDI_CHANNEL));
+  Serial.printf("  Invert NeoStick Left: %s\r\n", (NEOSTRIP_INVERT_YES == EEPROM.read(EEPROM_ADDR_INVERT_NEOSTRIP_1)) ? "True" : "False");
+  Serial.printf("  Invert NeoStick Right: %s\r\n", (NEOSTRIP_INVERT_YES == EEPROM.read(EEPROM_ADDR_INVERT_NEOSTRIP_2)) ? "True" : "False");
   DEBUG_PRINTLN("*** DONE ***");
   DEBUG_PRINTLN();
 }

--- a/Software/SweepStation/Nonvolatile.h
+++ b/Software/SweepStation/Nonvolatile.h
@@ -22,12 +22,24 @@ enum stationType_t
 };
 
 /**
+ * Interpret whether to invert the neostrip by using value or (127 - value) in the xStation functions that set the neostrip index 
+ */
+enum neoStripInvertState_t
+{
+  NEOSTRIP_INVERT_YES     = 0x00,
+  NEOSTRIP_INVERT_NO      = 0x01,
+  NEOSTRIP_INVERT_DEFAULT = 0xFF  // NOTE that unset EEPROM regions empirically default to 0xFF on Teensy, this will be logically equivalent to a NEOSTRIP_INVERT_NO
+};
+
+/**
  * EEPROM layout
  */
 #define EEPROM_ADDR_MIN 0x00
 #define EEPROM_ADDR_STATION_ID   0x10
 #define EEPROM_ADDR_STATION_TYPE 0x11
 #define EEPROM_ADDR_MIDI_CHANNEL 0x12
+#define EEPROM_ADDR_INVERT_NEOSTRIP_1 0x13
+#define EEPROM_ADDR_INVERT_NEOSTRIP_2 0x14
 #define EEPROM_ADDR_MAX 0x7F // this is the limit for the TEENSY_LC
 
 /**

--- a/Software/SweepStation/Preferences.h
+++ b/Software/SweepStation/Preferences.h
@@ -79,6 +79,8 @@ typedef struct
   uint8_t presence_cc;
   uint8_t MIDI_Channel;
   stationType_t HW_Type;
+  neoStripInvertState_t invertLeft;
+  neoStripInvertState_t invertRight;
 } config_t;
 
 #endif //__PREFERENCES_H__

--- a/Software/SweepStation/SweepStation.ino
+++ b/Software/SweepStation/SweepStation.ino
@@ -128,7 +128,8 @@ void setup()
   in_config.presence_cc    = MIDI_GEN_PURPOSE_5;
   in_config.MIDI_Channel   = EEPROM.read(EEPROM_ADDR_MIDI_CHANNEL);
   in_config.HW_Type        = (stationType_t) EEPROM.read(EEPROM_ADDR_STATION_TYPE);
-
+  in_config.invertLeft     = (neoStripInvertState_t) EEPROM.read(EEPROM_ADDR_INVERT_NEOSTRIP_1);
+  in_config.invertRight    = (neoStripInvertState_t) EEPROM.read(EEPROM_ADDR_INVERT_NEOSTRIP_2);
   ArcadeButton0.SetMIDIParams(in_config.MIDI_Channel, in_config.button0_cc);
   ArcadeButton1.SetMIDIParams(in_config.MIDI_Channel, in_config.button1_cc);
   
@@ -298,7 +299,7 @@ static void pingCheck(bool nextPingIsLeft)
     if(left_curr_bend_val != left_prev_bend_val && abs(left_curr_bend_val - left_prev_bend_val) < PREFS_ULTRA_ONEBYTE_MAX_DELTA)
     {
       usbMIDI.sendControlChange(in_config.pbend_left_cc, left_curr_bend_val, in_config.MIDI_Channel);
-      updateNeoPixelStick(NeoStickLeft, left_curr_bend_val, in_config.HW_Type);
+      updateNeoPixelStick(NeoStickLeft, left_curr_bend_val, in_config.HW_Type, in_config.invertLeft);
     }    
   }
   else
@@ -325,7 +326,7 @@ static void pingCheck(bool nextPingIsLeft)
     if(right_curr_bend_val != right_prev_bend_val && abs(right_curr_bend_val - right_prev_bend_val) < PREFS_ULTRA_ONEBYTE_MAX_DELTA)
     {
       usbMIDI.sendControlChange(in_config.pbend_right_cc, right_curr_bend_val, in_config.MIDI_Channel);
-      updateNeoPixelStick(NeoStickRight, right_curr_bend_val, in_config.HW_Type);
+      updateNeoPixelStick(NeoStickRight, right_curr_bend_val, in_config.HW_Type, in_config.invertRight);
     }
   }
 }


### PR DESCRIPTION
Deal with any potential install issues by individually writing to EEPROM for stations with inverted sensors. Ideally we'd never use this, but good to be prepared.

By Provisioning the EEPROM again and setting invert1 and invert2, we can flip individual ultrasonic sensors without changing the running code, and keeping the running software true to the latest in GitHub at time of release. 