### PR TITLE
PIR Presence Option 1: Remove presence MIDI CC messages of any form.

### DIFF
--- a/Software/PercussionStation/PercussionStation.ino
+++ b/Software/PercussionStation/PercussionStation.ino
@@ -130,7 +130,7 @@ void setup()
   in_config.yaw_neg_cc   = MIDI_UNDEFINED_0;
   in_config.trigger_cc   = MIDI_UNDEFINED_1;
   in_config.thumb_cc     = MIDI_UNDEFINED_2;
-  in_config.presence_cc  = MIDI_UNDEFINED_3;
+  in_config.presence_cc  = MIDI_UNDEFINED_3; // TODO currently never sent out 
   in_config.MIDI_Channel = EEPROM.read(EEPROM_ADDR_MIDI_CHANNEL);
   in_config.HW_Type = (stationType_t) EEPROM.read(EEPROM_ADDR_STATION_TYPE);
 
@@ -155,7 +155,7 @@ void setup()
   delay(10000);
   printBanner();
   printNonvolConfig();
-  usbMIDI.sendControlChange(in_config.presence_cc, 73, in_config.MIDI_Channel);
+  //usbMIDI.sendControlChange(in_config.presence_cc, 73, in_config.MIDI_Channel);
   digitalWrite(TEENSY_LED_PIN, LOW); 
   ping_time = 0;
 }
@@ -427,7 +427,7 @@ static void rampUp(bool *outBool, uint8_t *prevIncrement, unsigned long start_mi
     ArcadeButton5.SetLowValue((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS) * increment);
     ArcadeButton6.SetLowValue((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS) * increment);
     ArcadeButton7.SetLowValue((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS) * increment);
-    usbMIDI.sendControlChange(in_config.presence_cc, 73 + 6 * increment, in_config.MIDI_Channel);
+    //usbMIDI.sendControlChange(in_config.presence_cc, 73 + 6 * increment, in_config.MIDI_Channel);
     *prevIncrement = increment;
   }
 }
@@ -461,7 +461,7 @@ static void rampDown(bool *outBool, uint8_t *prevIncrement, unsigned long start_
     ArcadeButton5.SetLowValue(PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE - ((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS)*increment));
     ArcadeButton6.SetLowValue(PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE - ((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS)*increment));
     ArcadeButton7.SetLowValue(PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE - ((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS)*increment));
-    usbMIDI.sendControlChange(in_config.presence_cc, 127 - 6 * increment, in_config.MIDI_Channel);
+    //usbMIDI.sendControlChange(in_config.presence_cc, 127 - 6 * increment, in_config.MIDI_Channel);
     *prevIncrement = increment;
   }
 }
@@ -485,7 +485,7 @@ static void ClearCCs(config_t in_config)
   usbMIDI.sendControlChange(in_config.pitch_neg_cc, 0, in_config.MIDI_Channel);
   usbMIDI.sendControlChange(in_config.yaw_pos_cc, 0, in_config.MIDI_Channel);
   usbMIDI.sendControlChange(in_config.yaw_neg_cc, 0, in_config.MIDI_Channel);
-  usbMIDI.sendControlChange(in_config.presence_cc, 73, in_config.MIDI_Channel);
+  //usbMIDI.sendControlChange(in_config.presence_cc, 73, in_config.MIDI_Channel);
 }
 
 /**

--- a/Software/SweepStation/SweepStation.ino
+++ b/Software/SweepStation/SweepStation.ino
@@ -125,7 +125,7 @@ void setup()
   in_config.button1_cc     = MIDI_GEN_PURPOSE_2;
   in_config.pbend_left_cc  = MIDI_GEN_PURPOSE_3;
   in_config.pbend_right_cc = MIDI_GEN_PURPOSE_4;
-  in_config.presence_cc    = MIDI_GEN_PURPOSE_5;
+  in_config.presence_cc    = MIDI_GEN_PURPOSE_5; // TODO currently never sent out 
   in_config.MIDI_Channel   = EEPROM.read(EEPROM_ADDR_MIDI_CHANNEL);
   in_config.HW_Type        = (stationType_t) EEPROM.read(EEPROM_ADDR_STATION_TYPE);
 
@@ -408,7 +408,7 @@ static void rampUp(bool *outBool, uint8_t *prevIncrement, unsigned long start_mi
   {
     ArcadeButton0.SetLowValue((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS) * increment);
     ArcadeButton1.SetLowValue((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS) * increment);
-    usbMIDI.sendControlChange(in_config.presence_cc, 73 + 6 * increment, in_config.MIDI_Channel);
+    //usbMIDI.sendControlChange(in_config.presence_cc, 73 + 6 * increment, in_config.MIDI_Channel);
     *prevIncrement = increment;
   }
 }
@@ -435,7 +435,7 @@ static void rampDown(bool *outBool, uint8_t *prevIncrement, unsigned long start_
   {
     ArcadeButton0.SetLowValue(PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE - ((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS)*increment));
     ArcadeButton1.SetLowValue(PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE - ((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS)*increment));
-    usbMIDI.sendControlChange(in_config.presence_cc, 127 - 6 * increment, in_config.MIDI_Channel);
+    //usbMIDI.sendControlChange(in_config.presence_cc, 127 - 6 * increment, in_config.MIDI_Channel);
     *prevIncrement = increment;
   }
 }
@@ -446,7 +446,7 @@ static void ClearCCs(config_t in_config)
   usbMIDI.sendControlChange(in_config.button1_cc, 0, in_config.MIDI_Channel);
   usbMIDI.sendControlChange(in_config.pbend_left_cc, 0, in_config.MIDI_Channel);
   usbMIDI.sendControlChange(in_config.pbend_right_cc, 0, in_config.MIDI_Channel);
-  usbMIDI.sendControlChange(in_config.presence_cc, 73, in_config.MIDI_Channel);
+  //usbMIDI.sendControlChange(in_config.presence_cc, 73, in_config.MIDI_Channel);
 }
 
 /**


### PR DESCRIPTION
So with this branch, the PIR message stuff will still cause the LEDs to ramp up and ramp down, but will no longer send a MIDI message- so will not be controlling volume of any subsystems or anything.

This is 1 option (of 2) for how to deal with this PIR presence issue. There will be another PR with another option, but we should select one of these branches and just delete the other.