### PR TITLE
PIR Presence Option 2: Re-scale presence MIDI messages

### DIFF
--- a/Software/PercussionStation/PercussionStation.ino
+++ b/Software/PercussionStation/PercussionStation.ino
@@ -462,7 +462,8 @@ static void rampDown(bool *outBool, uint8_t *prevIncrement, unsigned long start_
     ArcadeButton5.SetLowValue(PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE - ((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS)*increment));
     ArcadeButton6.SetLowValue(PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE - ((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS)*increment));
     ArcadeButton7.SetLowValue(PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE - ((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS)*increment));
-    usbMIDI.sendControlChange(in_config.presence_cc, 127 - 6 * increment, in_config.MIDI_Channel);
+    int presenceVal = constrain(127 - (13 * increment), 0, 127);
+    usbMIDI.sendControlChange(in_config.presence_cc, presenceVal, in_config.MIDI_Channel);
     *prevIncrement = increment;
   }
 }

--- a/Software/PercussionStation/PercussionStation.ino
+++ b/Software/PercussionStation/PercussionStation.ino
@@ -155,7 +155,7 @@ void setup()
   delay(10000);
   printBanner();
   printNonvolConfig();
-  usbMIDI.sendControlChange(in_config.presence_cc, 73, in_config.MIDI_Channel);
+  usbMIDI.sendControlChange(in_config.presence_cc, 0, in_config.MIDI_Channel);
   digitalWrite(TEENSY_LED_PIN, LOW); 
   ping_time = 0;
 }
@@ -427,7 +427,8 @@ static void rampUp(bool *outBool, uint8_t *prevIncrement, unsigned long start_mi
     ArcadeButton5.SetLowValue((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS) * increment);
     ArcadeButton6.SetLowValue((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS) * increment);
     ArcadeButton7.SetLowValue((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS) * increment);
-    usbMIDI.sendControlChange(in_config.presence_cc, 73 + 6 * increment, in_config.MIDI_Channel);
+    int presenceVal = constrain(13 * increment, 0, 127);
+    usbMIDI.sendControlChange(in_config.presence_cc, presenceVal, in_config.MIDI_Channel);
     *prevIncrement = increment;
   }
 }
@@ -485,7 +486,7 @@ static void ClearCCs(config_t in_config)
   usbMIDI.sendControlChange(in_config.pitch_neg_cc, 0, in_config.MIDI_Channel);
   usbMIDI.sendControlChange(in_config.yaw_pos_cc, 0, in_config.MIDI_Channel);
   usbMIDI.sendControlChange(in_config.yaw_neg_cc, 0, in_config.MIDI_Channel);
-  usbMIDI.sendControlChange(in_config.presence_cc, 73, in_config.MIDI_Channel);
+  usbMIDI.sendControlChange(in_config.presence_cc, 0, in_config.MIDI_Channel);
 }
 
 /**

--- a/Software/SweepStation/SweepStation.ino
+++ b/Software/SweepStation/SweepStation.ino
@@ -145,7 +145,7 @@ void setup()
   NeoStickRight.show();
   ClearCCs(in_config);
   delay(10000);
-  usbMIDI.sendControlChange(in_config.presence_cc, 73, in_config.MIDI_Channel);
+  usbMIDI.sendControlChange(in_config.presence_cc, 0, in_config.MIDI_Channel);
   digitalWrite(TEENSY_LED_PIN, LOW);
   ping_time = millis();
 }
@@ -408,7 +408,8 @@ static void rampUp(bool *outBool, uint8_t *prevIncrement, unsigned long start_mi
   {
     ArcadeButton0.SetLowValue((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS) * increment);
     ArcadeButton1.SetLowValue((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS) * increment);
-    usbMIDI.sendControlChange(in_config.presence_cc, 73 + 6 * increment, in_config.MIDI_Channel);
+    int presenceVal = constrain(13 * increment, 0, 127);
+    usbMIDI.sendControlChange(in_config.presence_cc, presenceVal, in_config.MIDI_Channel);
     *prevIncrement = increment;
   }
 }
@@ -435,7 +436,8 @@ static void rampDown(bool *outBool, uint8_t *prevIncrement, unsigned long start_
   {
     ArcadeButton0.SetLowValue(PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE - ((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS)*increment));
     ArcadeButton1.SetLowValue(PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE - ((PREFS_ARCADE_BUTTON_PWM_LOW_PRESENCE/PREFS_RAMP_INCREMENTS)*increment));
-    usbMIDI.sendControlChange(in_config.presence_cc, 127 - 6 * increment, in_config.MIDI_Channel);
+    int presenceVal = constrain(127 - (13 * increment), 0, 127);
+    usbMIDI.sendControlChange(in_config.presence_cc, presenceVal, in_config.MIDI_Channel);
     *prevIncrement = increment;
   }
 }
@@ -446,7 +448,7 @@ static void ClearCCs(config_t in_config)
   usbMIDI.sendControlChange(in_config.button1_cc, 0, in_config.MIDI_Channel);
   usbMIDI.sendControlChange(in_config.pbend_left_cc, 0, in_config.MIDI_Channel);
   usbMIDI.sendControlChange(in_config.pbend_right_cc, 0, in_config.MIDI_Channel);
-  usbMIDI.sendControlChange(in_config.presence_cc, 73, in_config.MIDI_Channel);
+  usbMIDI.sendControlChange(in_config.presence_cc, 0, in_config.MIDI_Channel);
 }
 
 /**


### PR DESCRIPTION
See #7 for more details, but only this PR or #7 should be merged in and the other deleted, depending on the approach we choose in upstream integration. 

This just changes the scale of the ramp-up and ramp-down messages, but still sends one in setup() for each station, and still ramps up and down with CC messages. 